### PR TITLE
Fix build errors for IoT-Lab tutorial

### DIFF
--- a/arch/platform/iotlab/openlab/drivers/stm32/unique_id.c
+++ b/arch/platform/iotlab/openlab/drivers/stm32/unique_id.c
@@ -29,7 +29,7 @@
 #include "printf.h"
 #include "debug.h"
 
-const openlab_uid_t const *uid = (const openlab_uid_t *const) UNIQUE_ID_BASE_ADDRESS;
+const openlab_uid_t * const uid = (const openlab_uid_t *const) UNIQUE_ID_BASE_ADDRESS;
 
 void uid_print()
 {

--- a/arch/platform/iotlab/openlab/drivers/unique_id.h
+++ b/arch/platform/iotlab/openlab/drivers/unique_id.h
@@ -57,7 +57,7 @@ typedef union
 /**
  * Pointer to the Unique ID.
  */
-extern const openlab_uid_t const *uid;
+extern const openlab_uid_t * const uid;
 
 /**
  * Return a 16b uid processed from uid

--- a/arch/platform/iotlab/radio-rf2xx.c
+++ b/arch/platform/iotlab/radio-rf2xx.c
@@ -70,7 +70,11 @@ extern rf2xx_t RF2XX_DEVICE;
  * Instead, we use rf2xx_reg_write and rf2xx_reg_read in the sending and receiving routines. This, however breaks
  * should the driver be interrupted by an ISR. In TSCH, this never happens as transmissions and receptions are
  * done from rtimer interrupt. Keep this disabled for ContikiMAC and NullRDC. */
+#ifdef MAC_CONF_WITH_TSCH
 #define RF2XX_WITH_TSCH MAC_CONF_WITH_TSCH
+#else
+#define RF2XX_WITH_TSCH 0
+#endif
 
 #define RF2XX_MAX_PAYLOAD 125
 #if RF2XX_SOFT_PREPARE


### PR DESCRIPTION
Following the [Contiki-NG IoT-Lab tutorial ](https://www.iot-lab.info/tutorials/contiki-ng-compilation/) fails with the following build errors

* Duplicate 'const' declaration in unique_id.h
```
In file included from ../../../arch/platform/iotlab/openlab/platform/iotlab-m3/iotlab-m3.c:34:0:
../../../arch/platform/iotlab/openlab/drivers/unique_id.h:60:28: error: duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
 extern const openlab_uid_t const *uid;
```
* Duplicate 'const' declaration in unique_id.c
```
../../../arch/platform/iotlab/openlab/drivers/stm32/unique_id.c:32:21: error: duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
 const openlab_uid_t const *uid = (const openlab_uid_t *const) UNIQUE_ID_BASE_ADDRESS;
```
* MAC_CONF_WITH_TSCH undeclared
```
../../../arch/platform/iotlab/./radio-rf2xx.c: In function 'rf2xx_wr_transmit':
../../../arch/platform/iotlab/./radio-rf2xx.c:73:25: error: 'MAC_CONF_WITH_TSCH' undeclared (first use in this function); did you mean 'MAC_CONF_WITH_CSMA'?
 #define RF2XX_WITH_TSCH MAC_CONF_WITH_TSCH
```

This PR fixes the build errors.