### PR TITLE
Improved rtimer to use unsigned 32 bits variable

### DIFF
--- a/arch/platform/iotlab/iotlab-def.h
+++ b/arch/platform/iotlab/iotlab-def.h
@@ -50,7 +50,7 @@
 
 #define CLOCK_CONF_SECOND 100
 typedef uint32_t  clock_time_t;
-#define RTIMER_CONF_CLOCK_SIZE 2
+#define RTIMER_CONF_CLOCK_SIZE 4
 
 /* ---------------------------------------- */
 /*

--- a/arch/platform/iotlab/rtimer-arch.c
+++ b/arch/platform/iotlab/rtimer-arch.c
@@ -60,7 +60,7 @@ void rtimer_arch_init(void)
 
 rtimer_clock_t rtimer_arch_now(void)
 {
-    return timer_time( RTIMER_TIMER );
+    return soft_timer_time();
 }
 
 /*-----------------------------------------------------------------------------------*/


### PR DESCRIPTION
While working on the Energest implementation I noticed that we were using a 16 bits rtimer. However the openlab platform supports a way around the 16 bits timer. It has a wraparound counter that can fix the overflows. 
A 16 bits timer in this platform would wraparound every 2 seconds, this was causing wrong measurements in the energest.