### PR TITLE
Fixed the bug of double variable definition of 'platform_reset_cause_…

### DIFF
--- a/arch/platform/iotlab/openlab/platform/iotlab-m3/iotlab-m3.c
+++ b/arch/platform/iotlab/openlab/platform/iotlab-m3/iotlab-m3.c
@@ -40,7 +40,7 @@
 #include "printf.h"
 #include "debug.h"
 
-platform_reset_cause_t platform_reset_cause;
+extern platform_reset_cause_t platform_reset_cause;
 __attribute__((weak)) int32_t platform_should_start_watchdog();
 
 // Use iotlab_uid as mac address


### PR DESCRIPTION
When running the "hello-world" contiki-ng example, and using `arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/`, there was a duplicated variable definition identified in the following files: 
- `arch/platform/iotlab/openlab/platform/iotlab-m3/iotlab-m3.c` and
- `arch/platform/iotlab/./openlab-port.c`
Since the compiler identified the one in `openlab-port.c` defined first, we include `extern` in the second file. 